### PR TITLE
Moved exportation functionality from BokehDataAnnotator to SupervisableDataset

### DIFF
--- a/hover/core/explorer/functionality.py
+++ b/hover/core/explorer/functionality.py
@@ -146,13 +146,6 @@ class BokehDataAnnotator(BokehBaseExplorer):
             height_policy="fit",
             width_policy="min",
         )
-        self.annotator_export = Dropdown(
-            label="Export",
-            button_type="warning",
-            menu=["Excel", "CSV", "JSON", "pickle"],
-            height_policy="fit",
-            width_policy="min",
-        )
 
         def callback_apply():
             """
@@ -177,48 +170,10 @@ class BokehDataAnnotator(BokehBaseExplorer):
             self._update_sources()
             self._good(f"Updated annotator plot at {current_time()}")
 
-        def callback_export(event, path_root=None):
-            """
-            A callback on clicking the 'self.annotator_export' button.
-
-            Saves the dataframe to a pickle.
-            """
-            import pandas as pd
-
-            export_format = event.item
-
-            # auto-determine the export path root
-            if path_root is None:
-                timestamp = current_time("%Y%m%d%H%M%S")
-                path_root = f"hover-annotated-df-{timestamp}"
-
-            export_df = pd.concat(self.dfs, axis=0, sort=False, ignore_index=True)
-
-            if export_format == "Excel":
-                export_path = f"{path_root}.xlsx"
-                export_df.to_excel(export_path, index=False)
-            elif export_format == "CSV":
-                export_path = f"{path_root}.csv"
-                export_df.to_csv(export_path, index=False)
-            elif export_format == "JSON":
-                export_path = f"{path_root}.json"
-                export_df.to_json(export_path, orient="records")
-            elif export_format == "pickle":
-                export_path = f"{path_root}.pkl"
-                export_df.to_pickle(export_path)
-            else:
-                raise ValueError(f"Unexpected export format {export_format}")
-
-            self._good(f"Saved DataFrame to {export_path}")
-
-        # keep the references to the callbacks
+        # assign the callback and keep the reference
         self._callback_apply = callback_apply
-        self._callback_export = callback_export
-
-        # assign callbacks
         self.annotator_apply.on_click(self._callback_apply)
         self.annotator_apply.on_click(self._callback_subset_display)
-        self.annotator_export.on_click(self._callback_export)
 
     def plot(self):
         """

--- a/hover/core/explorer/specialization.py
+++ b/hover/core/explorer/specialization.py
@@ -47,7 +47,7 @@ class BokehTextAnnotator(BokehDataAnnotator, BokehForText):
         layout_rows = (
             row(self.search_pos, self.search_neg),
             row(self.data_key_button_group),
-            row(self.annotator_input, self.annotator_apply, self.annotator_export),
+            row(self.annotator_input, self.annotator_apply),
             row(*self._dynamic_widgets.values()),
         )
         return column(*layout_rows)
@@ -116,7 +116,7 @@ class BokehAudioAnnotator(BokehDataAnnotator, BokehForAudio):
         """Define the layout of widgets."""
         layout_rows = (
             row(self.data_key_button_group),
-            row(self.annotator_input, self.annotator_apply, self.annotator_export),
+            row(self.annotator_input, self.annotator_apply),
             row(*self._dynamic_widgets.values()),
         )
         return column(*layout_rows)
@@ -184,7 +184,7 @@ class BokehImageAnnotator(BokehDataAnnotator, BokehForImage):
         """Define the layout of widgets."""
         layout_rows = (
             row(self.data_key_button_group),
-            row(self.annotator_input, self.annotator_apply, self.annotator_export),
+            row(self.annotator_input, self.annotator_apply),
             row(*self._dynamic_widgets.values()),
         )
         return column(*layout_rows)

--- a/tests/core/test_dataset.py
+++ b/tests/core/test_dataset.py
@@ -49,6 +49,10 @@ class TestSupervisableTextDataset:
         df = dataset.to_pandas(use_df=True)
         df = dataset.to_pandas(use_df=False)
         dataset = SupervisableTextDataset.from_pandas(df)
+        
+        for _item in ["Excel", "CSV", "JSON", "pickle"]:
+            _event = MenuItemClick(_explorer.annotator_export, item=_item)
+            dataset._callback_export(_event)
 
     @staticmethod
     def test_compute_2d_embedding(mini_supervisable_text_dataset, dummy_vectorizer):

--- a/tests/core/test_explorer.py
+++ b/tests/core/test_explorer.py
@@ -105,11 +105,6 @@ class TestBokehDataAnnotator:
 
             _explorer._callback_apply()
 
-        # it should be sufficient to test export for just one class
-        for _item in ["Excel", "CSV", "JSON", "pickle"]:
-            _event = MenuItemClick(_explorer.annotator_export, item=_item)
-            _explorer._callback_export(_event)
-
 
 @pytest.mark.core
 class TestBokehTextSoftLabel:


### PR DESCRIPTION
This seems to more sense as `SupervisableDataset` keeps a centralized version of the dataset, whereas `BokehDataAnnotator` is one of the `explorers` that are connected to it. This change also allows consistent and cleaner file I/O with `SupervisableDataset.to_pandas()`.